### PR TITLE
Symlink dynamic library after Elixir build

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -81,6 +81,7 @@ defmodule Mix.Tasks.Compile.Nif do
         if do_cmd(port) != 0 do
           raise Mix.Error, message: "Error compiling #{file}"
         end
+        Mix.Project.build_structure
         :ok
     end
   end


### PR DESCRIPTION
When adding geef as a dependency in an Elixir project, it compiles OK but cannot find the shared library at runtime. The following steps create a sample project with geef as a dependency and then fail when attempting to load the git repository:

```
$ mix new geef_test
$ cd geef_test
$ git init

$ vim mix.exs
#  # Add the geef dependency.
#  defp deps do
#    [{:geef, git: "git://github.com/carlosmn/geef.git"}]
#  end

$ mix deps.get
$ mix run -e 'Geef.Repository.open!(".")'

22:26:10.001 [warn]  The on_load function for module geef_nif returned {:error,
 {:load_failed,
  'Failed to load NIF library: \'dlopen(/Users/asheehan/tmp/geef_test/_build/dev/lib/geef/priv/geef.so, 2): image not found\''}}

** (UndefinedFunctionError) function :geef_nif.repository_open/1 is undefined (module :geef_nif is not available)
    :geef_nif.repository_open(".")
    src/geef_repo.erl:39: :geef_repo.open/1
    lib/geef/repository.ex:7: Geef.Repository.open!/1
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
    (elixir) lib/code.ex:168: Code.eval_string/3
    (elixir) lib/enum.ex:651: Enum."-each/2-lists^foreach/1-0-"/2
```

It appears that the `geef.so` file was located at `deps/geef/priv/geef.so` but the application expected it to be in `_build/dev/lib/geef/priv/geef.so`. I looked at another project using C code to see how they handled it ([riverrun/comeonin](https://github.com/riverrun/comeonin/blob/930f516049bfba2c513ead47ef5cf92768392d78/mix.exs#L18)), and it seems like the call to `Mix.Project.build_structure` is what creates the symlink. Not sure if this is the correct approach, but it fixed the issue for me.
## Versions

```
$ mix --version
Erlang/OTP 18 [erts-7.3] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Mix 1.3.0

$ elixir --version
Erlang/OTP 18 [erts-7.3] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Elixir 1.3.0
```
