### PR TITLE
Tree is second argument to geef_index_read_tree

### DIFF
--- a/c_src/index.c
+++ b/c_src/index.c
@@ -83,7 +83,7 @@ geef_index_read_tree(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 	if (!enif_get_resource(env, argv[0], geef_index_type, (void **) &index))
 		return enif_make_badarg(env);
 
-	if (!enif_get_resource(env, argv[0], geef_object_type, (void **) &tree))
+	if (!enif_get_resource(env, argv[1], geef_object_type, (void **) &tree))
 		return enif_make_badarg(env);
 
 	if (git_index_read_tree(index->index, (git_tree *)tree->obj) < 0)


### PR DESCRIPTION
Currently calling `geef_index.read_tree(index, tree)` raises an Argument Error, it looks like this is due to using the first argument twice in the underlying c code:

https://github.com/carlosmn/geef/blob/9e9aa23af7614cb398e99fb06019884af2cbcd79/c_src/index.c#L83-L87

This PR updates the second call to `enif_get_resource` to use the second argument (`argv[0]`)

I got to here by following the call stack below:

https://github.com/carlosmn/geef/blob/9e9aa23af7614cb398e99fb06019884af2cbcd79/src/geef_index.erl#L123

https://github.com/carlosmn/geef/blob/9e9aa23af7614cb398e99fb06019884af2cbcd79/src/geef_nif.erl#L180

